### PR TITLE
WIP: collect metadata for each task

### DIFF
--- a/src/azure_queue_service.js
+++ b/src/azure_queue_service.js
@@ -62,8 +62,8 @@ const processQueueMessages = async () => {
 
         const outputDir = "/maps";
 
-        // Pass the extracted values to initiateRendering
-        await initiateRendering(
+        // Pass the extracted values to initiateRendering, and receive the metadata
+        const metadata = await initiateRendering(
           style,
           null,
           null,
@@ -77,6 +77,8 @@ const processQueueMessages = async () => {
           outputDir,
           outputFilename,
         );
+
+        console.log("metadata", metadata);
 
         // Send completion message
         const completionMessage = `Finished rendering map`;

--- a/src/azure_queue_service.js
+++ b/src/azure_queue_service.js
@@ -1,6 +1,10 @@
 import { QueueServiceClient } from "@azure/storage-queue";
 
-import { parseListToFloat, validateInputOptions } from "./utils.js";
+import {
+  parseListToFloat,
+  validateInputOptions,
+  handleError,
+} from "./utils.js";
 import { initiateRendering } from "./initiate.js";
 
 // Connection string and queue names
@@ -22,79 +26,108 @@ const processQueueMessages = async () => {
     });
     const message = response.receivedMessageItems[0];
 
-    if (message) {
-      try {
-        const decodedMessageText = Buffer.from(
-          message.messageText,
-          "base64",
-        ).toString("utf8");
-        console.log(`Received queue message: '${decodedMessageText}'`);
-
-        // Parse the message text as JSON
-        const options = JSON.parse(decodedMessageText);
-
-        const {
-          style,
-          apiKey,
-          mapboxStyle,
-          monthYear,
-          overlay,
-          bounds,
-          minZoom = 0,
-          maxZoom,
-          outputFilename = "output",
-        } = options;
-
-        const boundsArray = parseListToFloat(bounds);
-
-        validateInputOptions(
-          style,
-          null,
-          null,
-          apiKey,
-          mapboxStyle,
-          monthYear,
-          overlay,
-          boundsArray,
-          minZoom,
-          maxZoom,
-        );
-
-        const outputDir = "/maps";
-
-        // Pass the extracted values to initiateRendering, and receive the metadata
-        const metadata = await initiateRendering(
-          style,
-          null,
-          null,
-          apiKey,
-          mapboxStyle,
-          monthYear,
-          overlay,
-          boundsArray,
-          minZoom,
-          maxZoom,
-          outputDir,
-          outputFilename,
-        );
-
-        console.log("metadata", metadata);
-
-        // Send completion message
-        const completionMessage = `Finished rendering map`;
-        await destinationQueueClient.sendMessage(completionMessage);
-      } finally {
-        // Delete the message from the source queue
-        await sourceQueueClient.deleteMessage(
-          message.messageId,
-          message.popReceipt,
-        );
-      }
-    } else {
+    // If no message is found, retry after 10 seconds
+    if (!message) {
       console.log("No message found. Retrying in 10 seconds...");
-      await new Promise((resolve) => setTimeout(resolve, 10 * 1000)); // Wait for 10 seconds before retrying
+      await new Promise((resolve) => setTimeout(resolve, 10 * 1000));
+      continue;
+    }
+
+    // Initialize variables with default or null values
+    let renderResult;
+    let decodedMessageText = "";
+    let options = {};
+    let style,
+      apiKey,
+      mapboxStyle,
+      monthYear,
+      overlay,
+      bounds,
+      minZoom,
+      maxZoom,
+      outputFilename;
+    let boundsArray = [];
+    const outputDir = "/maps"; // TODO: Get this from environment variable (or confirm that we are happy with this default value)
+
+    // Decode, parse, and validate the message
+    try {
+      decodedMessageText = Buffer.from(message.messageText, "base64").toString(
+        "utf8",
+      );
+      console.log(`Received queue message: '${decodedMessageText}'`);
+
+      options = JSON.parse(decodedMessageText);
+
+      ({
+        style,
+        apiKey,
+        mapboxStyle,
+        monthYear,
+        overlay,
+        bounds,
+        minZoom = 0,
+        maxZoom,
+        outputFilename = "output",
+      } = options);
+
+      boundsArray = parseListToFloat(bounds);
+
+      validateInputOptions(
+        style,
+        null,
+        null,
+        apiKey,
+        mapboxStyle,
+        monthYear,
+        overlay,
+        boundsArray,
+        minZoom,
+        maxZoom,
+      );
+    } catch (error) {
+      renderResult = handleError(error, "badRequest");
+      await sendCompletionMessage(
+        renderResult,
+        destinationQueueClient,
+        message,
+      );
+      continue;
+    }
+
+    // Initiate rendering
+    try {
+      renderResult = await initiateRendering(
+        style,
+        null,
+        null,
+        apiKey,
+        mapboxStyle,
+        monthYear,
+        overlay,
+        boundsArray,
+        minZoom,
+        maxZoom,
+        outputDir,
+        outputFilename,
+      );
+    } catch (error) {
+      renderResult = handleError(error, "internalServerError");
+    } finally {
+      await sendCompletionMessage(
+        renderResult,
+        destinationQueueClient,
+        message,
+      );
     }
   }
+};
+
+const sendCompletionMessage = async (renderResult, queueClient, message) => {
+  if (renderResult) {
+    const completionMessage = JSON.stringify(renderResult);
+    await queueClient.sendMessage(completionMessage);
+  }
+  await sourceQueueClient.deleteMessage(message.messageId, message.popReceipt);
 };
 
 processQueueMessages();

--- a/src/cli.js
+++ b/src/cli.js
@@ -105,7 +105,7 @@ console.log("Output directory: %j", outputDir);
 console.log("Output MBTiles filename: %j", outputFilename);
 console.log("------------------------------------------------------");
 
-const metadata = await initiateRendering(
+const renderResult = await initiateRendering(
   style,
   styleDir,
   sourceDir,
@@ -120,5 +120,5 @@ const metadata = await initiateRendering(
   outputFilename,
 );
 
-// output the metadata to console
-console.log("Task metadata:", metadata);
+// output the render result to console
+console.log("Render result:", renderResult);

--- a/src/cli.js
+++ b/src/cli.js
@@ -105,7 +105,7 @@ console.log("Output directory: %j", outputDir);
 console.log("Output MBTiles filename: %j", outputFilename);
 console.log("------------------------------------------------------");
 
-initiateRendering(
+const metadata = await initiateRendering(
   style,
   styleDir,
   sourceDir,
@@ -119,3 +119,6 @@ initiateRendering(
   outputDir,
   outputFilename,
 );
+
+// output the metadata to console
+console.log("Task metadata:", metadata);

--- a/src/download_resources.js
+++ b/src/download_resources.js
@@ -59,7 +59,7 @@ const downloadOnlineTiles = async (
     throw new Error("Invalid bounds provided");
   }
 
-  let sourceUrl, sourceAttribution, sourceName;
+  let sourceUrl, sourceAttribution, sourceName, sourceFormat;
   switch (style) {
     case "google":
       sourceUrl = `https://mt0.google.com/vt?lyrs=s&x={x}&y={y}&z={z}`;

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -8,7 +8,6 @@ import {
   validateMinMaxValues,
 } from "./tile_calculations.js";
 import { renderTile } from "./render_map.js";
-import { handleError } from "./utils.js";
 
 // Generate a MapGL style JSON object from a remote source
 // and an additional source.
@@ -218,7 +217,7 @@ export const generateMBTiles = async (
       });
     });
   } catch (err) {
-    return handleError(err, "writing to MBTiles file");
+    throw new Error(`Error writing MBTiles file: ${err}`);
   }
 
   // Move the generated MBTiles file to the output directory
@@ -245,14 +244,12 @@ export const generateMBTiles = async (
 
     readStream.pipe(writeStream);
   } catch (err) {
-    return handleError(err, "moving MBTiles file to output directory");
+    throw new Error(`Error moving MBTiles file: ${err}`);
   }
 
-  // Return metadata with success status
+  // Return with success status
   return {
-    status: "success",
     errorCode: null,
-    errorMessage: null,
     filename: `${outputFilename}.mbtiles`,
     filesize: fs.statSync(outputPath).size,
     numberOfTiles,

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -122,13 +122,14 @@ export const generateMBTiles = async (
   console.log(`Generating MBTiles file: ${tempPath}`);
 
   let numberOfTiles = 0;
+  let fileSize = 0;
 
   // Create a new MBTiles file
   const mbtiles = await new Promise((resolve, reject) => {
-    new MBTiles(`${tempPath}?mode=rwc`, (err, mbtiles) => {
-      if (err) {
-        console.error("Error opening MBTiles file:", err);
-        reject(err);
+    new MBTiles(`${tempPath}?mode=rwc`, (error, mbtiles) => {
+      if (error) {
+        console.error("Error opening MBTiles file:", error);
+        reject(error);
       } else {
         resolve(mbtiles);
       }
@@ -137,9 +138,9 @@ export const generateMBTiles = async (
 
   try {
     // Start writing to the MBTiles file
-    mbtiles.startWriting((err) => {
-      if (err) {
-        throw err;
+    mbtiles.startWriting((error) => {
+      if (error) {
+        throw error;
       } else {
         let metadata = {
           name: outputFilename,
@@ -159,13 +160,13 @@ export const generateMBTiles = async (
 
             // Merge the file metadata with the default metadata
             metadata = { ...metadata, ...metadataFromFile };
-          } catch (err) {
-            console.error(`Error reading metadata.json file: ${err}`);
+          } catch (error) {
+            console.error(`Error reading metadata.json file: ${error}`);
           }
         }
 
-        mbtiles.putInfo(metadata, (err) => {
-          if (err) throw err;
+        mbtiles.putInfo(metadata, (error) => {
+          if (error) throw error;
         });
       }
     });
@@ -216,8 +217,10 @@ export const generateMBTiles = async (
         resolve();
       });
     });
-  } catch (err) {
-    throw new Error(`Error writing MBTiles file: ${err}`);
+
+    fileSize = fs.statSync(tempPath).size;
+  } catch (error) {
+    throw new Error(`Error writing MBTiles file: ${error}`);
   }
 
   // Move the generated MBTiles file to the output directory
@@ -243,15 +246,15 @@ export const generateMBTiles = async (
     });
 
     readStream.pipe(writeStream);
-  } catch (err) {
-    throw new Error(`Error moving MBTiles file: ${err}`);
+  } catch (error) {
+    throw new Error(`Error moving MBTiles file: ${error}`);
   }
 
   // Return with success status
   return {
     errorMessage: null,
     filename: `${outputFilename}.mbtiles`,
-    filesize: fs.statSync(outputPath).size,
+    filesize: fileSize,
     numberOfTiles,
   };
 };

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -249,7 +249,7 @@ export const generateMBTiles = async (
 
   // Return with success status
   return {
-    errorCode: null,
+    errorMessage: null,
     filename: `${outputFilename}.mbtiles`,
     filesize: fs.statSync(outputPath).size,
     numberOfTiles,

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -8,6 +8,7 @@ import {
   validateMinMaxValues,
 } from "./tile_calculations.js";
 import { renderTile } from "./render_map.js";
+import { handleError } from "./utils.js";
 
 // Generate a MapGL style JSON object from a remote source
 // and an additional source.
@@ -121,6 +122,8 @@ export const generateMBTiles = async (
   const tempPath = `${tempDir}/${outputFilename}.mbtiles`;
   console.log(`Generating MBTiles file: ${tempPath}`);
 
+  let numberOfTiles = 0;
+
   // Create a new MBTiles file
   const mbtiles = await new Promise((resolve, reject) => {
     new MBTiles(`${tempPath}?mode=rwc`, (err, mbtiles) => {
@@ -197,6 +200,9 @@ export const generateMBTiles = async (
             mbtiles.putTile(zoom, x, y, tileBuffer, (err) => {
               if (err) throw err;
             });
+
+            // Increment the number of tiles
+            numberOfTiles++;
           } catch (error) {
             console.error(`Error rendering tile ${zoom}/${x}/${y}: ${error}`);
           }
@@ -208,38 +214,47 @@ export const generateMBTiles = async (
     await new Promise((resolve, reject) => {
       mbtiles.stopWriting((err) => {
         if (err) reject(err);
-        console.log(
-          `\x1b[32m${outputFilename}.mbtiles has been successfully generated!\x1b[0m`,
-        );
         resolve();
       });
     });
-  } finally {
-    // Move the generated MBTiles file to the output directory
-    const outputPath = `${outputDir}/${outputFilename}.mbtiles`;
-
-    try {
-      const readStream = fs.createReadStream(tempPath);
-      const writeStream = fs.createWriteStream(outputPath);
-
-      readStream.on("error", (err) => {
-        console.error(`Error reading MBTiles file: ${err}`);
-      });
-
-      writeStream.on("error", (err) => {
-        console.error(`Error writing MBTiles file: ${err}`);
-      });
-
-      writeStream.on("close", () => {
-        // Delete the temporary tiles directory and style
-        if (tempDir !== null) {
-          fs.promises.rm(tempDir, { recursive: true });
-        }
-      });
-
-      readStream.pipe(writeStream);
-    } catch (err) {
-      throw new Error(`Error moving MBTiles file: ${err}`);
-    }
+  } catch (err) {
+    return handleError(err, "writing to MBTiles file");
   }
+
+  // Move the generated MBTiles file to the output directory
+  const outputPath = `${outputDir}/${outputFilename}.mbtiles`;
+
+  try {
+    const readStream = fs.createReadStream(tempPath);
+    const writeStream = fs.createWriteStream(outputPath);
+
+    readStream.on("error", (err) => {
+      console.error(`Error reading MBTiles file: ${err}`);
+    });
+
+    writeStream.on("error", (err) => {
+      console.error(`Error writing MBTiles file: ${err}`);
+    });
+
+    writeStream.on("close", () => {
+      // Delete the temporary tiles directory and style
+      if (tempDir !== null) {
+        fs.promises.rm(tempDir, { recursive: true });
+      }
+    });
+
+    readStream.pipe(writeStream);
+  } catch (err) {
+    return handleError(err, "moving MBTiles file to output directory");
+  }
+
+  // Return metadata with success status
+  return {
+    status: "success",
+    errorCode: null,
+    errorMessage: null,
+    filename: `${outputFilename}.mbtiles`,
+    filesize: fs.statSync(outputPath).size,
+    numberOfTiles,
+  };
 };

--- a/src/initiate.js
+++ b/src/initiate.js
@@ -132,37 +132,33 @@ export const initiateRendering = async (
     });
   }
 
-  try {
-    let generateResult = await generateMBTiles(
-      styleObject,
-      styleDir,
-      sourceDir,
-      bounds,
-      minZoom,
-      maxZoom,
-      tempDir,
-      outputDir,
-      outputFilename,
-    );
+  let generateResult = await generateMBTiles(
+    styleObject,
+    styleDir,
+    sourceDir,
+    bounds,
+    minZoom,
+    maxZoom,
+    tempDir,
+    outputDir,
+    outputFilename,
+  );
 
-    console.log(
-      `\x1b[32m${outputFilename}.mbtiles has been successfully generated!\x1b[0m`,
-    );
+  console.log(
+    `\x1b[32m${outputFilename}.mbtiles has been successfully generated!\x1b[0m`,
+  );
 
-    // if successful, return the render result
-    return {
-      style: style,
-      status: "Success",
-      errorMessage: generateResult.errorMessage,
-      filename: generateResult.filename,
-      filesize: generateResult.filesize,
-      numberOfTiles: generateResult.numberOfTiles,
-      workBegun,
-      workEnded: new Date().toISOString(),
-    };
-  } catch (error) {
-    throw new Error(`Error generating MBTiles: ${error.message}`);
-  }
+  // if successful, return the render result
+  return {
+    style: style,
+    status: "Success",
+    errorMessage: generateResult.errorMessage,
+    filename: generateResult.filename,
+    filesize: generateResult.filesize,
+    numberOfTiles: generateResult.numberOfTiles,
+    workBegun,
+    workEnded: new Date().toISOString(),
+  };
 };
 
 export default initiateRendering;

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,12 +5,25 @@ export const raiseError = (msg) => {
   process.exit(1);
 };
 
-export const handleError = (error, message) => {
-  return {
-    status: "failed",
-    errorCode: "500",
-    errorMessage: `Error ${message}: ${error.message}`,
-  };
+export const handleError = (error, type) => {
+  if (type === "badRequest") {
+    // Something was caller's fault. They need to fix something then retry.
+    return {
+      status: "BadRequest",
+      errorMessage: `${error.message}`,
+    };
+  } else if (type === "internalServerError") {
+    return {
+      // Something was our fault. It's out of the caller's control.
+      status: "InternalServerError",
+      errorMessage: `${error.message}`,
+    };
+  } else {
+    return {
+      status: "UnknownError",
+      errorMessage: `${error.message}`,
+    };
+  }
 };
 
 // Currently supported list of online styles

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,14 @@ export const raiseError = (msg) => {
   process.exit(1);
 };
 
+export const handleError = (error, message) => {
+  return {
+    status: "failed",
+    errorCode: "500",
+    errorMessage: `Error ${message}: ${error.message}`,
+  };
+};
+
 // Currently supported list of online styles
 // When adding a new style, make sure to update this list
 const validOnlineStyles = [


### PR DESCRIPTION
## Goal

This is an approach to collecting metadata about each job run by map-gl-renderer, whether through the CLI or via a queue message. For the latter environment, we can later write this metadata to a database table. I would like to get some quick feedback on this approach before proceeding further: does the way in which I've implemented this, and the data I am collecting, make sense to others? Anything else to add?

## Log output

This is the metadata content upon a successful job:

```
{
  style: 'self',
  status: 'success',
  errorCode: null,
  errorMessage: null,
  filename: 'output.mbtiles',
  filesize: 200704,
  numberOfTiles: 6,
  numberOfAttempts: 1,
  workBegun: '2024-02-05T16:09:37.338Z',
  workEnded: '2024-02-05T16:09:37.812Z',
  expiration: '2025-02-04T21:58:49.812Z'
}
```

This is the metadata content when I have intentionally broken something in `generateMBTiles`:

```
{
  style: 'self',
  status: 'failed',
  errorCode: '500',
  errorMessage: 'Error writing to MBTiles file: calculateeTileRangeForBounds is not defined',
  filename: undefined,
  filesize: undefined,
  numberOfTiles: undefined,
  numberOfAttempts: 1,
  workBegun: '2024-02-05T16:10:39.625Z',
  workEnded: '2024-02-05T16:10:39.628Z',
  expiration: null
}
```

## What I changed

These are the variables I am collecting:

* `style`: The type of style requested (mapbox, bing, etc.).
* `status`: Success or failure.
* `errorCode`: The idea here is to document an error code that can clarify if the failure was a result of an internal error, or erroneous user input. Although this is a headless tool, we can use HTTP response codes for client (400) or server (500) as way to codify this.
* `errorMessage`: The content of the specific message being thrown.
* `filename`: The name of the file (e.g. value of `output`).
* `filesize`: Filesize of the file
* `numberOfTiles`: Figure this could be a helpful thing to show on the front end - the number of tiles stored in the mbtiles db
* `numberOfAttempts`: Right now I just have this set to 1, since we haven't done any iterative attempts to reprocess upon failure as of yet.
* `workBegun`: timestamp captured at the very beginning of the job.
* `workEnded`: timestamp captured upon success
* `expiration:` timestamp + 1 year captured upon success. (Thinking we could use this to eventually purge files that have expired.)

The implementation of this is being handled by returning these values instead of throwing an error directly. I have added this to any likely failure point in the main function `initiateRendering` as well as `generateMBTiles` (where a lot of the success metadata is being generated as well).

## What I am not doing

Right now I'm just console logging the metadata upon completion. I am not passing or writing this anywhere as of yet.

I have not considered timeout errors. I haven't seen it, but it's possible the flow could hang somewhere.