### PR TITLE
Terraform module to deploy on Azure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+deploy/
 node_modules/
 npm-debug.log
 Dockerfile

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,6 +1,9 @@
+# Since this project demonstrates a generic deployment for the open-source community,
+# ignore actual deployments:
+*.tfvars
+
 # Secrets tfvars
 **/secret.auto.tfvars
-
 
 # Local .terraform directories
 **/.terraform/*
@@ -16,12 +19,6 @@
 
 # Crash log files
 crash.log
-
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
-# .tfvars files are managed as part of configuration and so should be included in
-# version control.
-#
-# example.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,39 @@
+# Secrets tfvars
+**/secret.auto.tfvars
+
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Lock files for Terraform directories that CircleCI manages
+# (CircleCI is often the only thing that generates these and there's no good way
+# to have it commit them back to version control.)
+.terraform.lock.hcl
+.terraform.lock.hcl
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -13,7 +13,6 @@
 # (CircleCI is often the only thing that generates these and there's no good way
 # to have it commit them back to version control.)
 .terraform.lock.hcl
-.terraform.lock.hcl
 
 # Crash log files
 crash.log

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,9 +24,10 @@ terraform init
 2. **Create a terraform.tfvars file** in your project directory. This file will contain the values for the variables defined in the `variables.tf` file, most of which refer to your existing Azure infrastructure. Example:
 
 ```ini
-resource_group_name     = "mappacker"
-container_registry_name = "myacr"
-storage_account_name    = "mappackerplayground"
+tile_renderer_docker_image = "my.azurecr.io/mapgl-tile-renderer:example"
+resource_group_name        = "mappacker"
+container_registry_name    = "myacr"
+storage_account_name       = "mappackerplayground"
 ```
 
 If managing multiple deployments, make a separate `*.tfvars` file for each,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,40 @@
+# Deploy as a Background Worker on Azure
+
+This folder contains Terraform modules designed to provision infrastructure
+to run MapGL Tile Renderer as a background worker on Azure.
+
+## Getting Started
+
+### Prerequisites
+
+- Terraform 1.7.x or later (Visit the [Terraform documentation](https://www.terraform.io/docs) for installation and usage instructions.)
+- Azure cloud account, with a few core pieces of infrastructure already provisioned:
+    * a storage account, which will be used to create a queue of work requests and to write offline mbtiles back to file storage;
+    * a container registry (TODO: we should host this for you)
+    * a single resource group containing all of the above
+
+### Usage
+
+1. **Initialize Terraform** in your project directory if you haven't done so already:
+
+```shell
+terraform init
+```
+
+2. **Create a terraform.tfvars file** in your project directory. This file will contain the values for the variables defined in the `variables.tf` file, most of which refer to your existing Azure infrastructure. Example:
+
+```ini
+resource_group_name     = "mappacker"
+container_registry_name = "myacr"
+storage_account_name    = "mappackerplayground"
+```
+
+3. **Plan and apply your configuration:**
+```shell
+terraform plan
+terraform apply
+```
+
+## Support
+
+For issues or questions regarding these modules, please open an issue in this repository.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,6 +29,9 @@ container_registry_name = "myacr"
 storage_account_name    = "mappackerplayground"
 ```
 
+If managing multiple deployments, make a separate `*.tfvars` file for each,
+then append `--var-file=«mydeployment».tfvars` in the `terraform` bash commands below.
+
 3. **Plan and apply your configuration:**
 ```shell
 terraform plan

--- a/deploy/mappacker.tf
+++ b/deploy/mappacker.tf
@@ -52,7 +52,7 @@ resource "azurerm_container_app" "mapgl_tile_renderer" {
   template {
     container {
       name   = "mbgl-tile-renderer"
-      image  = "${data.azurerm_container_registry.this.login_server}/mbgl-tile-renderer:test-3"
+      image  = var.tile_renderer_docker_image
       cpu    = "0.25"
       memory = "0.5Gi"
 

--- a/deploy/mapppacker.tf
+++ b/deploy/mapppacker.tf
@@ -1,0 +1,98 @@
+# Bare-bones stuff
+data "azurerm_resource_group" "this" {
+  name = "guardian"
+}
+data "azurerm_container_registry" "guardiancr" {
+  name                = "guardiancr"
+  resource_group_name = data.azurerm_resource_group.this.name
+}
+
+# Storage & Queue
+data "azurerm_storage_account" "this" {
+  name                = "bcmplayground"
+  resource_group_name = data.azurerm_resource_group.this.name
+}
+resource "azurerm_storage_queue" "mappacker_requests" {
+  name                 = "mappacker-requests"
+  storage_account_name = data.azurerm_storage_account.this.name
+}
+
+# Azure Container App
+resource "azurerm_container_app_environment" "this" {
+  name                = "guardian-mappacker-env"
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = "eastus2"
+}
+resource "azurerm_container_app" "mbgl_tile_renderer" {
+  name                         = "mappacker-worker"
+  resource_group_name          = data.azurerm_resource_group.this.name
+  container_app_environment_id = azurerm_container_app_environment.this.id
+  revision_mode                = "Single"
+
+
+  registry {
+    server               = data.azurerm_container_registry.guardiancr.login_server
+    username             = data.azurerm_container_registry.guardiancr.admin_username
+    password_secret_name = "containerregistry"
+  }
+  # This secret is not used by the application code, but is used by for
+  # Azure Container App to download the image.
+  # TODO: Remove this secret by instead using a user-assigned managed identity
+  # for Container App to connect to registry (see: registry {identity:...})
+  secret {
+    name  = "containerregistry"
+    value = data.azurerm_container_registry.guardiancr.admin_password
+  }
+
+  # This secret is used for scale rules.
+  secret {
+    name  = "queueconnection"
+    value = data.azurerm_storage_account.this.primary_connection_string
+  }
+
+  template {
+    container {
+      name  = "mbgl-tile-renderer"
+      image = "${data.azurerm_container_registry.guardiancr.login_server}/mbgl-tile-renderer:test-3"
+      cpu    = "0.25"
+      memory = "0.5Gi"
+
+      env {
+        name  = "QueueName"
+        value = "mappacker-requests"
+      }
+      env {
+        name  = "QueueConnectionString"
+        value = data.azurerm_storage_account.this.primary_connection_string
+      }
+
+      volume_mounts {
+        name = "mappacker-maps"
+        path = "/maps/"
+      }
+    }
+
+    volume {
+      name         = "mappacker-maps"
+      storage_name = "mappacker-maps"
+      storage_type = "AzureFile"
+    }
+
+    min_replicas = 0
+    max_replicas = 5
+
+    azure_queue_scale_rule {
+      name         = "scale-when-there-is-work"
+      queue_name   = azurerm_storage_queue.mappacker_requests.name
+      queue_length = 1
+      authentication {
+        secret_name       = "queueconnection"
+        trigger_parameter = "connection"
+      }
+    }
+  }
+
+  # no external ingress is needed for the worker
+  # ingress { external_enabled = false }
+
+}

--- a/deploy/provider.tf
+++ b/deploy/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.86"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -1,0 +1,32 @@
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type        = string
+}
+
+variable "container_registry_name" {
+  description = "The name of the container registry"
+  type        = string
+}
+
+variable "storage_account_name" {
+  description = "The name of the existing storage account"
+  type        = string
+}
+
+variable "container_app_environment_location" {
+  description = "Location for the container app environment"
+  type        = string
+  default     = "eastus2"
+}
+
+variable "container_app_name" {
+  description = "Name of the task worker container app"
+  type        = string
+  default     = "mappacker-worker"
+}
+
+variable "container_app_env_name" {
+  description = "Name of the task worker container environment"
+  type        = string
+  default     = "mappacker-env"
+}

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -8,6 +8,11 @@ variable "container_registry_name" {
   type        = string
 }
 
+variable "tile_renderer_docker_image" {
+  description = "The name of the docker image to launch"
+  type        = string
+}
+
 variable "storage_account_name" {
   description = "The name of the existing storage account"
   type        = string


### PR DESCRIPTION
## Goal

Resolve #30: demonstrate how to deploy on Azure

## What I changed

1. Add new folder `deploy/`, containing terraform modules. This folder is added to `.dockerignore`, and also has its own Terraform-specific `.gitignore`
2. Terraform module relies on a bit of existing (most likely shared) infrastructure, namely a storage account and container registry.  This can be specified by the user via Terraform variables.
3. Terraform module creates the Queue for new requests; the app container and its environment and scale-out rule.
4. README

## What I'm not doing here

* Currently we do not address ways to _share_ the Terraform state: that is, the mapping from resource names to actual deployed infrastructure.  This might result in conflicts if multiple developers all try to manage the same deployment.
* No explicit way to manage the docker image version that's being deployed.  Currently hard-coded to `:test-3` label

