### PR TITLE
Add output filename to `name` in mbtiles metadata

### DIFF
--- a/src/download_resources.js
+++ b/src/download_resources.js
@@ -53,6 +53,7 @@ const downloadOnlineTiles = async (
   bounds,
   minZoom,
   maxZoom,
+  outputFilename,
   tempDir,
 ) => {
   if (!bounds || bounds.length < 4) {
@@ -213,7 +214,7 @@ const downloadOnlineTiles = async (
   // Save metadata.json file with proper attribution according to
   // each source's terms of use
   const metadata = {
-    name: sourceName,
+    name: `${outputFilename} - ${sourceName}`,
     description: `XYZ tiles from ${sourceName}`,
     version: "1.0.0",
     attribution: sourceAttribution,
@@ -273,6 +274,7 @@ export const requestOnlineTiles = (
   bounds,
   minZoom,
   maxZoom,
+  outputFilename,
   tempDir,
 ) => {
   return new Promise(async (resolve, reject) => {
@@ -285,6 +287,7 @@ export const requestOnlineTiles = (
         bounds,
         minZoom,
         maxZoom,
+        outputFilename,
         tempDir,
       );
       resolve();

--- a/src/initiate.js
+++ b/src/initiate.js
@@ -58,6 +58,7 @@ export const initiateRendering = async (
         bounds,
         minZoom,
         maxZoom,
+        outputFilename,
         tempDir,
       );
     } catch (error) {


### PR DESCRIPTION
While using this tool to create an offline map for a partner, I discovered that the `name` row in the `metadata` table of the mbtiles file is what is used by Mapeo to provide a name for the background map. This was just set to the source of the tiles (e.g. bing, mapbox) which is not super descriptive and will get confusing if multiple maps are added with the same source. So this is a quick change to include the output filename in the name in a format `{outputFilename} - {sourceName}` (e.g. "Oelemarie River - Bing Maps Satellite")