### PR TITLE
Set maplibre Map mode to 'tile'

### DIFF
--- a/src/render_map.js
+++ b/src/render_map.js
@@ -39,6 +39,7 @@ export const renderTile = async (
   const map = new maplibre.Map({
     request: requestHandler(styleDir, sourceDir),
     ratio: 1,
+    mode: "tile",
   });
 
   map.load(styleObject);


### PR DESCRIPTION
Per https://github.com/ConservationMetrics/mapgl-tile-renderer/issues/41, this PR has mapgl-tile-renderer create a Maplibre-GL map with `mode: tile` to avoid label clipping across tiles.

Before:

![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/31662219/063a13e1-8337-427c-b451-c0cc4f015306)

After:

![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/31662219/051fb0dd-4246-47c3-978b-da3360bda538)

There is perhaps an additional batch of work to resolve label clipping even when the mode is set, as described in the above issue.