### PR TITLE
Add options for ratio and tileType

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Common options:
 * `-b` or `--bounds`: Bounding box in WSEN format, comma separated (required)
 * `-Z` or `--maxzoom`: Maximum zoom level (required)
 * `-z` or `--minzoom`: Minimum zoom level (optional, 0 if not provided)
+* `-r` or `--ratio`: Output pixel ratio (optional, 1 if not provided)
+* `-t` or `--tiletype`: Output Tile type (jpg, png, or webp) (optional, jpg if not provided)
 * `-o` or `--outputdir`: Output directory (optional, "outputs/" if not provided)
 * `-f` or `--filename`: Name of the output MBTiles file (optional, "output" if not provided)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Common options:
 * `-Z` or `--maxzoom`: Maximum zoom level (required)
 * `-z` or `--minzoom`: Minimum zoom level (optional, 0 if not provided)
 * `-r` or `--ratio`: Output pixel ratio (optional, 1 if not provided)
-* `-t` or `--tiletype`: Output Tile type (jpg, png, or webp) (optional, jpg if not provided)
+* `-t` or `--tiletype`: Output tile type (jpg, png, or webp) (optional, jpg if not provided)
 * `-o` or `--outputdir`: Output directory (optional, "outputs/" if not provided)
 * `-f` or `--filename`: Name of the output MBTiles file (optional, "output" if not provided)
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -78,8 +78,6 @@ program
 program.parse(process.argv);
 const options = program.opts();
 
-console.log(options);
-
 const {
   style,
   stylelocation: styleLocation,

--- a/src/cli.js
+++ b/src/cli.js
@@ -52,6 +52,7 @@ program
     "(Required) Maximum zoom level",
     parseInt,
   )
+  .option("-r, --ratio <number>", "Map pixel ratio (default 1)", Math.floor, 1)
   .option(
     "-o, --outputdir <type>",
     "Output directory (default 'outputs/')",
@@ -61,10 +62,23 @@ program
     "-f, --filename <type>",
     "Output filename (default 'output')",
     "output",
+  )
+  .option(
+    "-t, --tiletype <type>",
+    "Tile type (jpg, png, or webp)",
+    (type) => {
+      if (!["jpg", "png", "webp"].includes(type)) {
+        throw new Error("Invalid tile type");
+      }
+      return type;
+    },
+    "jpg",
   );
 
 program.parse(process.argv);
 const options = program.opts();
+
+console.log(options);
 
 const {
   style,
@@ -76,10 +90,12 @@ const {
   openstreetmap: openStreetMap,
   overlay,
   bounds,
+  ratio,
   minzoom: minZoom,
   maxzoom: maxZoom,
   outputdir: outputDir,
   filename: outputFilename,
+  tiletype,
 } = options;
 
 validateInputOptions(
@@ -92,8 +108,10 @@ validateInputOptions(
   openStreetMap,
   overlay,
   bounds,
+  ratio,
   minZoom,
   maxZoom,
+  tiletype,
 );
 
 console.log("\n\n-------- Rendering map tiles with Maplibre GL --------");
@@ -111,8 +129,10 @@ if (overlay) console.log("Overlay: %j", overlay);
 console.log("Bounding box: %j", bounds);
 console.log("Min zoom: %j", minZoom);
 console.log("Max zoom: %j", maxZoom);
+console.log("Ratio: %j", ratio);
 console.log("Output directory: %j", outputDir);
 console.log("Output MBTiles filename: %j", outputFilename);
+console.log("Output Tile Type: %j", tiletype);
 console.log("------------------------------------------------------");
 
 const renderResult = await initiateRendering(
@@ -125,10 +145,12 @@ const renderResult = await initiateRendering(
   openStreetMap,
   overlay,
   bounds,
+  ratio,
   minZoom,
   maxZoom,
   outputDir,
   outputFilename,
+  tiletype,
 );
 
 // output the render result to console

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -66,7 +66,7 @@ export const generateStyle = (
 };
 
 // Convert premultiplied image buffer from Mapbox GL to RGBA PNG format
-export const generateJPG = async (buffer, width, height, ratio) => {
+export const generateImage = async (buffer, width, height, ratio, tiletype) => {
   // Un-premultiply pixel values
   // Mapbox GL buffer contains premultiplied values, which are not handled
   // correctly by sharp https://github.com/mapbox/mapbox-gl-native/issues/9124
@@ -87,15 +87,22 @@ export const generateJPG = async (buffer, width, height, ratio) => {
     }
   }
 
-  return sharp(buffer, {
+  const image = sharp(buffer, {
     raw: {
       width: width * ratio,
       height: height * ratio,
       channels: 4,
     },
-  })
-    .jpeg()
-    .toBuffer();
+  });
+
+  switch (tiletype) {
+    case "jpg":
+      return image.jpeg().toBuffer();
+    case "png":
+      return image.png().toBuffer();
+    case "webp":
+      return image.webp().toBuffer();
+  }
 };
 
 // Generate MBTiles file from a given style, bounds, and zoom range
@@ -104,11 +111,13 @@ export const generateMBTiles = async (
   styleDir,
   sourceDir,
   bounds,
+  ratio,
   minZoom,
   maxZoom,
   tempDir,
   outputDir,
   outputFilename,
+  tiletype,
 ) => {
   const tempPath = `${tempDir}/${outputFilename}.mbtiles`;
   console.log(`Generating MBTiles file: ${tempPath}`);
@@ -183,6 +192,8 @@ export const generateMBTiles = async (
               styleObject,
               styleDir,
               sourceDir,
+              ratio,
+              tiletype,
               zoom,
               x,
               y,

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -66,7 +66,7 @@ export const generateStyle = (
 };
 
 // Convert premultiplied image buffer from Mapbox GL to RGBA PNG format
-export const generateImage = async (buffer, width, height, ratio, tiletype) => {
+export const generateImage = async (buffer, tiletype, width, height, ratio) => {
   const image = sharp(buffer, {
     raw: {
       premultiplied: true,

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -67,28 +67,9 @@ export const generateStyle = (
 
 // Convert premultiplied image buffer from Mapbox GL to RGBA PNG format
 export const generateImage = async (buffer, width, height, ratio, tiletype) => {
-  // Un-premultiply pixel values
-  // Mapbox GL buffer contains premultiplied values, which are not handled
-  // correctly by sharp https://github.com/mapbox/mapbox-gl-native/issues/9124
-  // since we are dealing with 8-bit RGBA values, normalize alpha onto 0-255
-  // scale and divide it out of RGB values
-
-  for (let i = 0; i < buffer.length; i += 4) {
-    const alpha = buffer[i + 3];
-    const norm = alpha / 255;
-    if (alpha === 0) {
-      buffer[i] = 0;
-      buffer[i + 1] = 0;
-      buffer[i + 2] = 0;
-    } else {
-      buffer[i] /= norm;
-      buffer[i + 1] = buffer[i + 1] / norm;
-      buffer[i + 2] = buffer[i + 2] / norm;
-    }
-  }
-
   const image = sharp(buffer, {
     raw: {
+      premultiplied: true,
       width: width * ratio,
       height: height * ratio,
       channels: 4,

--- a/src/initiate.js
+++ b/src/initiate.js
@@ -20,10 +20,12 @@ export const initiateRendering = async (
   openStreetMap,
   overlay,
   bounds,
+  ratio,
   minZoom,
   maxZoom,
   outputDir,
   outputFilename,
+  tiletype,
 ) => {
   console.log("Initiating rendering...");
 
@@ -161,11 +163,13 @@ export const initiateRendering = async (
     styleDir,
     sourceDir,
     bounds,
+    ratio,
     minZoom,
     maxZoom,
     tempDir,
     outputDir,
     outputFilename,
+    tiletype,
   );
 
   console.log(

--- a/src/render_map.js
+++ b/src/render_map.js
@@ -2,7 +2,7 @@ import maplibre from "@maplibre/maplibre-gl-native";
 
 import { calculateNormalizedCenterCoords } from "./tile_calculations.js";
 import { requestHandler } from "./request_resources.js";
-import { generateJPG } from "./generate_resources.js";
+import { generateImage } from "./generate_resources.js";
 
 // Render the map, returning a Promise.
 const renderMap = (map, options) => {
@@ -23,6 +23,8 @@ export const renderTile = async (
   styleObject,
   styleDir,
   sourceDir,
+  ratio,
+  tiletype,
   zoom,
   x,
   y,
@@ -38,7 +40,7 @@ export const renderTile = async (
   // MapLibre native documentation: https://github.com/maplibre/maplibre-native/blob/main/platform/node/README.md
   const map = new maplibre.Map({
     request: requestHandler(styleDir, sourceDir),
-    ratio: 1,
+    ratio: ratio,
     mode: "tile",
   });
 
@@ -55,7 +57,13 @@ export const renderTile = async (
   // Clean up the map instance to free resources
   map.release();
 
-  const jpeg = await generateJPG(buffer, tileSize, tileSize, 1);
+  const image = await generateImage(
+    buffer,
+    tileSize,
+    tileSize,
+    ratio,
+    tiletype,
+  );
 
-  return jpeg;
+  return image;
 };

--- a/src/render_map.js
+++ b/src/render_map.js
@@ -59,10 +59,10 @@ export const renderTile = async (
 
   const image = await generateImage(
     buffer,
+    tiletype,
     tileSize,
     tileSize,
     ratio,
-    tiletype,
   );
 
   return image;


### PR DESCRIPTION
## Goal
Adds cli options for 'pixel ratio' and 'tiletype' to allow changing the type of tiles generated from 'jpg', 'png', or 'webp'. It defaults to a ratio of 1 and tiletype of 'jpg', which were the old hardcoded defaults.

## Screenshots
with ratio 1, tiletype webp
`node . --style self --stylelocation styles\http_pmtiles_local_spites_fonts.json --stylesources styles\data --bounds "-79,37,-78,38" -Z 
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/c21c9c38-3fdf-4054-a7ce-4ccd83d6c6d6)

with ratio 2, tiletype webp
`node . --style self --stylelocation styles\http_pmtiles_local_spites_fonts.json --stylesources styles\data --bounds "-79,37,-78,38" -Z 11 -f wdb_11_r2_webp -r 2 -t webp`
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/2ccd61ff-d6c1-4382-a7d0-4e7c9740d0c1)

with ratio 1, tiletype png
`node . --style self --stylelocation styles\http_pmtiles_local_spites_fonts.json --stylesources styles\data --bounds "-79,37,-78,38" -Z 11 -f wdb_11_r1_png -r 1 -t png`
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/ace34dcb-1692-489e-bafa-10354c6b02cf)

with ratio 2, tiletype png
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/ab388859-5e75-4e2f-898c-a8b693f7783b)

with ratio 1, tiletype jpg
node . --style self --stylelocation styles\http_pmtiles_local_spites_fonts.json --stylesources styles\data --bounds "-79,37,-78,38" -Z 11 -f wdb_11_r1_jpg -r 1 -t jpg
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/7ae33932-ba51-4d10-a279-97a7c5fa0594)

with ratio 2, tiletype jpg
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/dcff572d-440f-4bc7-8e13-8efed2113242)
