### PR TITLE
Use tiletype for mbtiles format in metadata

### DIFF
--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -126,7 +126,7 @@ export const generateMBTiles = async (
       } else {
         let metadata = {
           name: outputFilename,
-          format: "jpg",
+          format: tiletype,
           minzoom: minZoom,
           maxzoom: maxZoom,
           type: "overlay",


### PR DESCRIPTION
Fixes https://github.com/ConservationMetrics/mapgl-tile-renderer/issues/46

Updates the mbtiles metadata format to use the tiletype variable instead of being hardcoded to "jpg"


Example.

No tiletype specified
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/e136e25d-1941-4d01-9efd-056d54968cf3)

tiletype of webp used in command
![image](https://github.com/ConservationMetrics/mapgl-tile-renderer/assets/3792408/dfd1f9ae-e09a-44a8-8413-2e7ef61901d9)

