### PR TITLE
Optionally generate thumbnail image of map style with bounding box

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Common options:
 * `-t` or `--tiletype`: Output tile type (jpg, png, or webp) (optional, jpg if not provided)
 * `-o` or `--outputdir`: Output directory (optional, "outputs/" if not provided)
 * `-f` or `--filename`: Name of the output MBTiles file (optional, "output" if not provided)
+* `-T` or `--thumbnail`: Optionally, generate a thumbnail of your style with a bounding box overlaid (false if not provided)
 
 ## CLI example usage
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "prettier --write ./src",
     "prepare": "[ -f ./node_modules/.bin/husky ] && husky install || echo 'Skipping husky install'",
-    "test": "jest --coverage --silent"
+    "test": "jest --coverage --silent",
+    "test-verbose": "jest --coverage"
   },
   "bin": {
     "mapgl-tile-renderer": "src/cli.js"

--- a/src/azure_queue_service.js
+++ b/src/azure_queue_service.js
@@ -90,8 +90,8 @@ const handleNewRequest = async (options, message) => {
     ratio,
     tiletype,
     outputDir,
-    outputFilename;
-  thumbnail;
+    outputFilename,
+    thumbnail;
   let boundsArray = [];
   let requestId;
 

--- a/src/azure_queue_service.js
+++ b/src/azure_queue_service.js
@@ -91,6 +91,7 @@ const handleNewRequest = async (options, message) => {
     tiletype,
     outputDir,
     outputFilename;
+  thumbnail;
   let boundsArray = [];
   let requestId;
 
@@ -109,6 +110,7 @@ const handleNewRequest = async (options, message) => {
       ratio = 1,
       tiletype = "jpg",
       outputFilename = "output",
+      thumbnail = false,
     } = options);
 
     requestId = options.requestId;
@@ -156,6 +158,7 @@ const handleNewRequest = async (options, message) => {
       tiletype,
       outputDir,
       outputFilename,
+      thumbnail,
     );
   } catch (error) {
     renderResult = handleError(error, "internalServerError");

--- a/src/azure_queue_service.js
+++ b/src/azure_queue_service.js
@@ -233,8 +233,8 @@ const writeRenderResult = async (renderResult, message, requestId) => {
   await sourceQueueClient.deleteMessage(message.messageId, message.popReceipt);
 };
 
-function camelToSnakeCase(str) {
+const camelToSnakeCase = (str) => {
   return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-}
+};
 
 processQueueMessages();

--- a/src/cli.js
+++ b/src/cli.js
@@ -73,6 +73,12 @@ program
     "-f, --filename <type>",
     "Output filename (default 'output')",
     "output",
+  )
+  .option(
+    "-T, --thumbnail <boolean>",
+    "Generate a thumbnail image with bounding box overlaid. Set to 'true' or 'false' (default 'false')",
+    (value) => value.toLowerCase() === "true",
+    false,
   );
 
 program.parse(process.argv);
@@ -94,6 +100,7 @@ const {
   tiletype,
   outputdir: outputDir,
   filename: outputFilename,
+  thumbnail,
 } = options;
 
 validateInputOptions(
@@ -129,6 +136,7 @@ console.log("Ratio: %j", ratio);
 console.log("Output tile type: %j", tiletype);
 console.log("Output directory: %j", outputDir);
 console.log("Output MBTiles filename: %j", outputFilename);
+console.log("Generate thumbnail: %j", thumbnail);
 console.log("------------------------------------------------------");
 
 const renderResult = await initiateRendering(
@@ -147,6 +155,7 @@ const renderResult = await initiateRendering(
   tiletype,
   outputDir,
   outputFilename,
+  thumbnail,
 );
 
 // output the render result to console

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -7,7 +7,7 @@ import {
   calculateTileRangeForBounds,
   validateMinMaxValues,
 } from "./tile_calculations.js";
-import { renderTile } from "./render_map.js";
+import { renderTile, renderThumbnail } from "./render_map.js";
 import {
   basicMapStyle,
   openStreetMapStyle,
@@ -65,7 +65,7 @@ export const generateStyle = (
   return styleObject;
 };
 
-// Convert premultiplied image buffer from Mapbox GL to RGBA PNG format
+// Convert premultiplied image buffer from MapGL to RGBA PNG format
 export const generateImage = async (buffer, tiletype, width, height, ratio) => {
   const image = sharp(buffer, {
     raw: {
@@ -84,6 +84,31 @@ export const generateImage = async (buffer, tiletype, width, height, ratio) => {
     case "webp":
       return image.webp().toBuffer();
   }
+};
+
+// Generate a thumbnail image for the style and bounds
+export const generateThumbnail = async (
+  styleObject,
+  styleDir,
+  sourceDir,
+  bounds,
+  ratio,
+  outputDir,
+  outputFilename,
+) => {
+  const thumbnailBuffer = await renderThumbnail(
+    styleObject,
+    styleDir,
+    sourceDir,
+    bounds,
+    ratio,
+  );
+
+  const outputPath = path.join(outputDir, `${outputFilename}-thumbnail.jpg`);
+
+  fs.writeFileSync(outputPath, thumbnailBuffer);
+
+  console.log(`Thumbnail generated at ${outputPath}`);
 };
 
 // Generate MBTiles file from a given style, bounds, and zoom range

--- a/src/generate_resources.js
+++ b/src/generate_resources.js
@@ -104,11 +104,14 @@ export const generateThumbnail = async (
     ratio,
   );
 
-  const outputPath = path.join(outputDir, `${outputFilename}-thumbnail.jpg`);
+  const thumbnailFilename = `${outputFilename}-thumbnail.jpg`;
+  const outputPath = path.join(outputDir, thumbnailFilename);
 
   fs.writeFileSync(outputPath, thumbnailBuffer);
 
   console.log(`Thumbnail generated at ${outputPath}`);
+
+  return thumbnailFilename;
 };
 
 // Generate MBTiles file from a given style, bounds, and zoom range

--- a/src/initiate.js
+++ b/src/initiate.js
@@ -2,7 +2,11 @@ import os from "os";
 import fs from "fs";
 import path from "path";
 
-import { generateStyle, generateMBTiles } from "./generate_resources.js";
+import {
+  generateStyle,
+  generateMBTiles,
+  generateThumbnail,
+} from "./generate_resources.js";
 import {
   requestOnlineTiles,
   requestOpenStreetMapData,
@@ -26,6 +30,7 @@ export const initiateRendering = async (
   tiletype,
   outputDir,
   outputFilename,
+  thumbnail,
 ) => {
   console.log("Initiating rendering...");
 
@@ -156,6 +161,20 @@ export const initiateRendering = async (
     });
   }
 
+  // Generate thumbnail, if requested
+  if (thumbnail) {
+    await generateThumbnail(
+      styleObject,
+      styleDir,
+      sourceDir,
+      bounds,
+      ratio,
+      outputDir,
+      outputFilename,
+    );
+  }
+
+  // Generate MBTiles file
   let generateResult = await generateMBTiles(
     styleObject,
     styleDir,

--- a/src/initiate.js
+++ b/src/initiate.js
@@ -161,9 +161,10 @@ export const initiateRendering = async (
     });
   }
 
+  let thumbnailFilename;
   // Generate thumbnail, if requested
   if (thumbnail) {
-    await generateThumbnail(
+    thumbnailFilename = await generateThumbnail(
       styleObject,
       styleDir,
       sourceDir,
@@ -202,6 +203,7 @@ export const initiateRendering = async (
     filename: generateResult.filename,
     fileSize: generateResult.fileSize,
     numberOfTiles: generateResult.numberOfTiles,
+    thumbnailFilename: thumbnailFilename,
     workBegun,
     workEnded: new Date().toISOString(),
   };

--- a/src/render_map.js
+++ b/src/render_map.js
@@ -26,10 +26,7 @@ export const renderThumbnail = async (
   bounds,
   ratio,
 ) => {
-  // Here, we use a 1:2 aspect ratio for the thumbnail
-  const width = 512;
-  const height = width / 2;
-
+  const imageSize = 512;
   const center = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2];
 
   // Add bounding box as a source to the styleObject
@@ -84,13 +81,13 @@ export const renderThumbnail = async (
   const buffer = await renderMap(map, {
     zoom: 4, // Adjust zoom level as needed
     center: center,
-    width: width,
-    height: height,
+    height: imageSize,
+    width: imageSize,
   });
 
   map.release();
 
-  const image = await generateImage(buffer, "jpg", width, height, ratio);
+  const image = await generateImage(buffer, "jpg", imageSize, imageSize, ratio);
 
   return image;
 };

--- a/src/render_map.js
+++ b/src/render_map.js
@@ -18,6 +18,80 @@ const renderMap = (map, options) => {
   });
 };
 
+// Render a thumbnail image for the style and bounds
+export const renderThumbnail = async (
+  styleObject,
+  styleDir,
+  sourceDir,
+  bounds,
+  ratio,
+) => {
+  const tileSize = 512;
+  const center = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2];
+
+  // Add bounding box as a source to the styleObject
+  styleObject.sources["bounding-box"] = {
+    type: "geojson",
+    data: {
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [bounds[0], bounds[1]],
+            [bounds[0], bounds[3]],
+            [bounds[2], bounds[3]],
+            [bounds[2], bounds[1]],
+            [bounds[0], bounds[1]],
+          ],
+        ],
+      },
+    },
+  };
+
+  // Add bounding box style to the styleObject
+  styleObject.layers.push({
+    id: "bounding-box",
+    type: "fill",
+    source: "bounding-box",
+    paint: {
+      "fill-color": "#3BB2D0",
+      "fill-opacity": 0.4,
+    },
+  });
+
+  styleObject.layers.push({
+    id: "bounding-box-border",
+    type: "line",
+    source: "bounding-box",
+    paint: {
+      "line-color": "#3BB2D0",
+      "line-width": 2,
+      "line-dasharray": [2, 2], // This creates a dotted line
+    },
+  });
+
+  const map = new maplibre.Map({
+    request: requestHandler(styleDir, sourceDir),
+    ratio: ratio,
+  });
+
+  map.load(styleObject);
+
+  const buffer = await renderMap(map, {
+    zoom: 4, // Adjust zoom level as needed
+    center: center,
+    height: tileSize,
+    width: tileSize,
+  });
+
+  map.release();
+
+  const image = await generateImage(buffer, "jpg", tileSize, tileSize, ratio);
+
+  return image;
+};
+
 // Render map tile for a given style, zoom level, and tile coordinates
 export const renderTile = async (
   styleObject,

--- a/src/render_map.js
+++ b/src/render_map.js
@@ -26,7 +26,10 @@ export const renderThumbnail = async (
   bounds,
   ratio,
 ) => {
-  const tileSize = 512;
+  // Here, we use a 1:2 aspect ratio for the thumbnail
+  const width = 512;
+  const height = width / 2;
+
   const center = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2];
 
   // Add bounding box as a source to the styleObject
@@ -81,13 +84,13 @@ export const renderThumbnail = async (
   const buffer = await renderMap(map, {
     zoom: 4, // Adjust zoom level as needed
     center: center,
-    height: tileSize,
-    width: tileSize,
+    width: width,
+    height: height,
   });
 
   map.release();
 
-  const image = await generateImage(buffer, "jpg", tileSize, tileSize, ratio);
+  const image = await generateImage(buffer, "jpg", width, height, ratio);
 
   return image;
 };

--- a/tests/test.js
+++ b/tests/test.js
@@ -95,7 +95,7 @@ test("Generates a MapGL style JSON object from Esri and overlay", async () => {
   expect(styleObject).toEqual(expectedStyleObject);
 });
 
-test("Generates MBTiles from self-provided style with MBTiles and GeoJSON source", async () => {
+test("Generates MBTiles and thumbnail from self-provided style with MBTiles and GeoJSON source", async () => {
   await initiateRendering(
     "self",
     "./tests/fixtures/alert/style-with-geojson.json",
@@ -111,7 +111,8 @@ test("Generates MBTiles from self-provided style with MBTiles and GeoJSON source
     1,
     "jpg",
     tempDir,
-    "output"
+    "output",
+    true
   );
 
   await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -120,7 +121,11 @@ test("Generates MBTiles from self-provided style with MBTiles and GeoJSON source
   const stats = fs.statSync(`${tempDir}/output.mbtiles`);
   expect(stats.size).toBeGreaterThan(69632)
 
+  // Expect output-thumbnail.jpg to exist
+  expect(fs.existsSync(`${tempDir}/output-thumbnail.jpg`)).toBe(true);
+
   fs.unlinkSync(`${tempDir}/output.mbtiles`);
+  fs.unlinkSync(`${tempDir}/output-thumbnail.jpg`);
 });
 
 test("Generates MBTiles from self-provided style with MBTiles source that uses font glyphs", async () => {


### PR DESCRIPTION
## Goal

To provide an option to generate a of the map style, with a transparent fill, dashed outline box representing the MBTiles bounds.

## What I changed

* Added a `thumbnail` input parameter (and corresponding CLI flag) for `awaitRendering` function.
* If set to true, call `generateThumbnail` which utilizes an async function `renderThumbnail` to generate a 512x512 JPG with two bounding box layers overlaid on the chosen map style.
* The file is saved as `{outputFilename}-thumbnail.jpg` in the same location as the MBTiles files.
* Support use of this new feature in the ASQ code (so it can be included in a map request by MapPacker or other).
* Added this new feature to one of the existing tests.

## What I'm not doing here

For now, I have hard-coded the zoom level for the map thumbnail  to be `4`, since I have found that (1) this zoom level provides a decent contextual overview in many parts of the world, (2) even very small bounds are visible with this zoom level, (3) I have yet to see any MBTiles generated that exceed the bounds of a zoom level 4 image (they would be very large). But if need be, we can handle the zoom level in a more nuanced way to account for a large bbox.