### PR TITLE
ASQ: Delete message if `dequeueCount` > 3

### DIFF
--- a/src/azure_queue_service.js
+++ b/src/azure_queue_service.js
@@ -45,6 +45,19 @@ const processQueueMessages = async () => {
       continue;
     }
 
+    // Check dequeueCount
+    // https://learn.microsoft.com/en-us/rest/api/storageservices/get-messages#response-body
+    if (message.dequeueCount > 3) {
+      console.log(
+        `Message processing has been attempted more than 3 times. Deleting message with ID: ${message.messageId}`,
+      );
+      await sourceQueueClient.deleteMessage(
+        message.messageId,
+        message.popReceipt,
+      );
+      continue;
+    }
+
     try {
       // Decode and parse the message
       let decodedMessageText = Buffer.from(


### PR DESCRIPTION
## Goal

To permanently delete a map request message after a mapgl-tile-renderer worker has attempted to process it more than 3 times (after which we may reasonably assume that it is prone to continue failing).

## What I changed

* Check if `dequeueCount` (which is returned in the message response body) > 3, and if so, delete the message.